### PR TITLE
Fixed failing build and changed 'MacOS' to 'macOS'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.2.1
+
+- Fixed failing build due to package.json looking for icon.icns instead of icons.icns
+- Changed 'MacOS' to 'macOS' in README
+
+
 # 0.2.0
 
 - Add font selector. "Roboto" font is used by default.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Create, style, organize your personal notes!
 ![Main Screenshot](/static/screenshots/win.png)
 
 ### :surfer: Platforms
-Ray is based on Electron platform and can be run on Windows, MacOS and Linux. 
-At this moment you can download distributive for Windows (tested on Windows 10), MacOS and Linux releases will be added later.
+Ray is based on Electron platform and can be run on Windows, macOS and Linux. 
+At this moment you can download distributive for Windows (tested on Windows 10), macOS and Linux releases will be added later.
 
 <a href="https://github.com/teslor/ray/releases/download/v0.2.0/Ray-0.2.0-x64.exe">Download v0.2.0 for Windows x64</a>
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
       "dist/electron/**/*"
     ],
     "mac": {
-      "icon": "build/icons/icon.icns"
+      "icon": "build/icons/icons.icns"
     },
     "win": {
       "target": "nsis",


### PR DESCRIPTION
Updated CHANGELOG w/changes (named this pull request v0.2.1)
- Fixed build failure (package.json was looking for icon.icns instead of icons.icns)
- Changed 'MacOS' to 'macOS' in README